### PR TITLE
修改点击重新上传事件后后，取消操作引起的异常

### DIFF
--- a/src/components/avatar-cutter/avatar-cutter.vue
+++ b/src/components/avatar-cutter/avatar-cutter.vue
@@ -566,7 +566,7 @@ export default {
           this.setPreview()
         })
       }
-      reader.readAsDataURL(fileObj)
+      if(fileObj) reader.readAsDataURL(fileObj)
     },
 
     // 确认


### PR DESCRIPTION
上传头像后，如果点击重新上传按钮，会出现空异常。